### PR TITLE
Update to go from Scala 3 RC to Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
-val scala3Version = "3.0.0-RC3"
+val scala2Version = "2.13.5"
+val scala3Version = "3.0.0"
 
 lazy val root = project
   .in(file("."))
@@ -9,11 +10,14 @@ lazy val root = project
     scalaVersion := scala3Version,
 
     libraryDependencies ++= Seq(
-      ("org.specs2" %% "specs2-core" % "4.11.0" % Test).withDottyCompat(scala3Version),
-      "org.typelevel" %% "cats-effect-testing-specs2" % "1.1.0" % Test,
-      "org.typelevel" %% "cats-core" % "2.6.0",
-      "org.typelevel" %% "cats-effect" % "3.1.0"
-    )
+      ("org.specs2" %% "specs2-core" % "4.12.0" % Test).cross(CrossVersion.for3Use2_13),
+      "org.typelevel" %% "cats-effect-testing-specs2" % "1.1.1" % Test,
+      "org.typelevel" %% "cats-core" % "2.6.1",
+      "org.typelevel" %% "cats-effect" % "3.1.1"
+    ),
+
+    // To cross compile with Scala 3 and Scala 2
+    crossScalaVersions := Seq(scala3Version, scala2Version)
   )
 
 

--- a/docker/Dockerfile.dependencies
+++ b/docker/Dockerfile.dependencies
@@ -2,7 +2,8 @@ FROM openjdk:11-buster AS dependencies
 
 # Install dependencies
 # Install sbt
-RUN echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list
+RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/apt/sources.list.d/sbt.list
+RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee /etc/apt/sources.list.d/sbt_old.list
 RUN curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add
 RUN apt-get update && apt-get install --yes --no-install-recommends ffmpeg sbt \
   && rm -rf /var/lib/apt/lists/*
@@ -16,6 +17,6 @@ WORKDIR /home/build/app
 
 # COPY --chown=<user>:<group> <hostPath> <containerPath>
 COPY --chown=build:build build.sbt ./
-COPY --chown=build:build project/build.properties project/plugins.sbt project/
+COPY --chown=build:build project/build.properties project/
 
 RUN sbt compile

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.7
+sbt.version=1.5.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.2")


### PR DESCRIPTION
# Reason
- Remove plugins.sbt as its no longer needed
- Read instructions here: https://www.scala-lang.org/blog/2021/04/08/scala-3-in-sbt.html