### PR TITLE
Create runnable

### DIFF
--- a/auto/build
+++ b/auto/build
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+docker-compose --file ./docker/docker-compose.yml build build
+docker-compose --file ./docker/docker-compose.yml down
+docker-compose --file ./docker/docker-compose.yml run build

--- a/auto/run
+++ b/auto/run
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-docker-compose --file ./docker/docker-compose.yml build production_editor
-docker-compose --file ./docker/docker-compose.yml down
-docker-compose --file ./docker/docker-compose.yml run production_editor
+# Load environment variables
+export $(cat ./docker/environment-variables.env | xargs)
 
+java -cp target/scala-3.0.0/video-and-audio-editor-assembly-0.1.0.jar editor.Main

--- a/docker/Dockerfile.dependencies
+++ b/docker/Dockerfile.dependencies
@@ -17,6 +17,6 @@ WORKDIR /home/build/app
 
 # COPY --chown=<user>:<group> <hostPath> <containerPath>
 COPY --chown=build:build build.sbt ./
-COPY --chown=build:build project/build.properties project/
+COPY --chown=build:build project/build.properties project/plugins.sbt project/
 
 RUN sbt compile

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     build:
       context: ..
       dockerfile: ./docker/Dockerfile
+    env_file:
+      - ./environment-variables.env
     environment:
       VIDEO_DIRECTORY: data/mp4
       AUDIO_DIRECTORY: data/mp3

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -25,3 +25,10 @@ services:
     volumes:
       - ${HOME}/dev/video-to-audio-editor:/home/build/app
 
+  build:
+    <<: *base
+    stdin_open: true
+    tty: true
+    command: sbt clean assembly
+    volumes:
+      - ${HOME}/dev/video-to-audio-editor:/home/build/app

--- a/docker/environment-variables.env
+++ b/docker/environment-variables.env
@@ -1,0 +1,5 @@
+VIDEO_DIRECTORY=data/mp4
+AUDIO_DIRECTORY=data/mp3
+PREPEND_TEMPLATE_DIRECTORY=data/prepend_templates
+PREPEND_INPUT_DIRECTORY=data/prepend_input
+PREPEND_OUTPUT_DIRECTORY=data/prepend_output

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.0.0")


### PR DESCRIPTION
# Reason

- Speed up execution by creating an executable file
- Run `auto/build` to create the file
- Run `auto/run` to keep running the executable file - Reduced time it takes to start!
- All you need is java!